### PR TITLE
fix: passage du modsec body limit a 110M

### DIFF
--- a/products/tdb/env.ini
+++ b/products/tdb/env.ini
@@ -5,8 +5,8 @@ product_name=tdb
 repo=mission-apprentissage/flux-retour-cfas
 # 1.1MB=1024^2+1024 
 # Nginx default is 1MB
-# 11MB=11*1024^2+1024
-modsec_body_limit=11535360
+# 110MB=110*1024^2+1024
+modsec_body_limit=115353600
 modsec_rule_engine=DetectionOnly
 
 [production]


### PR DESCRIPTION
fix: https://tableaudebord-apprentissage.atlassian.net/browse/DEVOPS-3

Changement de la règle modsec pour accepter des payloads plus important

⚠️ La règle reste en DetectionOnly, afin de vérifier dans un premier temps que la nouvelle limite (110M) est conforme à l'attendu