### PR TITLE
fix: docker compose volume bind configuration when including /var/lib/docker

### DIFF
--- a/.infra/files/app/docker-compose.system.yml
+++ b/.infra/files/app/docker-compose.system.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # The following variables define reusable configurations for deployment, providing consistent and predefined 
 # behaviors for updating, rolling back, and restarting services.
 
@@ -111,10 +109,10 @@ services:
     devices:
       - /dev/kmsg
     volumes:
-      - /:/rootfs:ro
+      - /:/rootfs:ro,rshared
       - /var/run:/var/run:ro
       - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
+      - /var/lib/docker/:/var/lib/docker:ro,rshared
       - /dev/disk/:/dev/disk:ro
     logging:
       driver: "fluentd"


### PR DESCRIPTION
Suite à la MAJ docker, nouvelle erreur:
`Error response from daemon: invalid mount config: must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root, daemon root: "/var/lib/docker", bind mount source: "/var/lib/docker/", propagation: "rprivate"`