### PR TITLE
feat: configuration de la politique d'accès S3 au bucket de logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,36 @@ La configuration de base contient la configuration:
 
 - [Ajouter un produit/environnement](./docs/provisionning.md)
 - [Gestion des accès d'un produit](./docs/manage_access.md)
+
+
+## TODO
+
+- [ ] Automatiser la vérification des utilisateurs ayant accès au S3 `OVH_S3_BUCKET`
+  - Aucun utilisateur n'est censé avoir la permission de supprimer des fichiers dans le bucket
+  - Seuls les utilisateurs lié à un membre de l'équipe peuvent avoir accès en lecture (c'est à dire les comptes nominatifs).
+  - L'utilisateur identifié par `OVH_S3_API_KEY` doit avoir la polique S3 suivante:
+    ```
+    {
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket"
+          ],
+          "Resource": "arn:aws:s3:::{{ OVH_S3_BUCKET }}"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:PutObject",
+            "s3:GetObject"
+          ],
+          "Resource": "arn:aws:s3:::{{ OVH_S3_BUCKET }}/*"
+        }
+      ]
+    }
+    ```
+- [ ] S'assurer que le bucket `OVH_S3_BUCKET` a bien l'option de chiffrement activée
+- [ ] Automatiser la configuration de l'access logging est activé `aws s3api put-bucket-logging --bucket <bucket> --bucket-logging-status file://logging.json`
+- [ ] Automatiser la configuration multi-région de OVH S3
+- [ ] Automatiser la configuration de la lifecyle policy


### PR DESCRIPTION
Listes d'actions faites manuellement:
- Limiter les permissions de l'utilisateur ayant accès au bucket de logs (`ListObject`, `GetObject` & `PutObject`)
- Activation du versioning sur le bucket pour garder l'historique meme en cas de suppression ou d'overwrite d'un fichier de logs
- Activation du server encryption S3
- Vérification de la configuration de bucket logging
- Ajout de la lifecycle policy pour supprimer les logs après 2ans
- Vérification des utilisateurs ayant la permission `DeleteObject` sur les buckets logs et access logs.
