### PR TITLE
fix: rendu des templates jinja dans get_ansible_var.sh (ssh:config)

### DIFF
--- a/.bin/scripts/known_hosts/get_ansible_var.sh
+++ b/.bin/scripts/known_hosts/get_ansible_var.sh
@@ -20,5 +20,26 @@ shift
 
 env_ini=$(product:ini_file "${PRODUCT_NAME}")
 
-ansible-inventory -i "${env_ini}" --list \
-  | jq -r --arg name "$VAR_NAME" '._meta.hostvars | values | map(.[$name]) | join(" ")'
+# `ansible-inventory --list` renvoie les hostvars NON rendues : une variable
+# comme `host_name={{ product_name }}-production` ressort telle quelle, puis se
+# fait découper sur les espaces côté appelant. On passe donc par le moteur de
+# template d'Ansible (module debug, connection=local => aucun SSH) pour obtenir
+# la valeur réellement rendue, y compris les références imbriquées.
+# Ordre aligné sur list_ips.sh : hosts triés, localhost exclu.
+ansible all -i "${env_ini}" --connection=local -m debug -a "var=${VAR_NAME}" -o 2> /dev/null \
+  | python3 -c '
+import sys, json, re
+rows = {}
+for line in sys.stdin:
+    m = re.match(r"^(\S+) \| \w+ => (\{.*\})\s*$", line)
+    if not m:
+        continue
+    host = m.group(1)
+    if host == "localhost":
+        continue
+    val = json.loads(m.group(2)).get(sys.argv[1])
+    if val in (None, "VARIABLE IS NOT DEFINED!"):
+        continue
+    rows[host] = val
+print(" ".join(rows[h] for h in sorted(rows)))
+' "${VAR_NAME}"


### PR DESCRIPTION
## Contexte

`ssh:config` générait un `~/.ssh/config.d/<produit>.config` corrompu :

```
Host {{ 51.178.234.71
Host product_name 54.37.59.132
Host }}-preview 57.128.2.134
```

## Cause

`ansible-inventory --list` renvoie les hostvars **non rendues**. La variable `host_name={{ product_name }}-production` ressortait littéralement, puis l'assignation `hostnames=($(...))` la découpait sur les espaces en 3 tokens, décalant tout le tableau.

## Changements

- `get_ansible_var.sh` passe désormais par le module `debug` d'Ansible (`--connection=local`, donc aucun SSH) pour récupérer la valeur réellement **rendue** par le moteur de template, y compris les références imbriquées.
- Parsing robuste en Python, ordre aligné sur `list_ips.sh` (hosts triés, `localhost` exclu).

## Plan de test

- [ ] `tools ssh:config lba` → vérifier que `~/.ssh/config.d/lba.config` contient bien `Host lba-preview / lba-recette / lba-production`
- [ ] Vérifier que l'ordre hostnames ↔ IPs reste cohérent
- [ ] Tester sur un produit à host_name littéral (ex: `mongodb`)