### PR TITLE
feat: ouvre le port métriques mongot (9946) - cluster lba

### DIFF
--- a/products/mongodb/nftables.lba.conf.jinja2
+++ b/products/mongodb/nftables.lba.conf.jinja2
@@ -85,6 +85,9 @@ table ip firewall {
     ip saddr $VPN tcp dport 27017 accept
     ip saddr $MONITORING tcp dport 27017 accept
 
+    # MongoDB Search (mongot) - métriques Prometheus
+    ip saddr $MONITORING tcp dport 9946 accept
+
   }
 
   chain forward {

--- a/products/mongodb/nftables.recette.conf.jinja2
+++ b/products/mongodb/nftables.recette.conf.jinja2
@@ -106,6 +106,9 @@ table ip firewall {
     ip saddr $VPN tcp dport 27017 accept
     ip saddr $MONITORING tcp dport 27017 accept
 
+    # MongoDB Search (mongot) - métriques Prometheus
+    ip saddr $MONITORING tcp dport 9946 accept
+
   }
 
   chain forward {


### PR DESCRIPTION
## Contexte

Prépare le monitoring de MongoDB Search (mongot) sur le cluster **lba** (recette + prod). Ouvre le port métriques Prometheus (9946) exposé par mongot, restreint au serveur de monitoring. Fait suite à mission-apprentissage/mongodb#65 (installation mongot).

Companion PR : mission-apprentissage/monitoring#69 (job Prometheus `mongot-lba`).

## Changements

- `products/mongodb/nftables.lba.conf.jinja2` / `nftables.recette.conf.jinja2` : `ip saddr $MONITORING tcp dport 9946 accept`
- Aucun changement sur bal/api/tdb/sandbox

## Non couvert

Le port health check mongot (8080) n'est pas exposé (pas de besoin identifié côté monitoring externe pour l'instant).

## Test plan

- [ ] Après déploiement : `nc -zv mongodb-lba-1.apprentissage.beta.gouv.fr 9946` depuis le serveur monitoring → succès ; depuis une IP hors liste → refus/timeout