### PR TITLE
chore: blacklist du scraper 94.130.70.34 (saturation MongoDB LBA)

### DIFF
--- a/.infra/files/app/tools/jail/blacklist-ips.sh
+++ b/.infra/files/app/tools/jail/blacklist-ips.sh
@@ -13,6 +13,8 @@ done
 ips+=(3.92.127.83)
 ips+=(82.65.116.94)
 ips+=(82.165.82.41)
+# scraper Hetzner (UA "node") — saturation MongoDB LBA le 2026-08-03
+ips+=(94.130.70.34)
 
 # specific blacklist
 bash /opt/app/tools/jail/ban-ip.sh "${ips[@]}"


### PR DESCRIPTION
## Contexte

Le 3 août, l'IP `94.130.70.34` (serveur client Hetzner anonyme, rDNS `static.34.70.130.94.clients.your-server.de`, UA `node`) a scrapé La bonne alternance en continu (~35 000 req/h, 24h/24, actif depuis fin juillet) : énumération des métiers via `/api/rome` et recherches d'offres commune par commune via `/api/v1/_private/jobs/min`. Résultat : secondaires MongoDB lba à 100 % CPU de 07h15 à 21h, recherches à 24–29 s au lieu de ~2 s.

L'IP n'est pas dans la liste ipsum (et ses rares voisines Hetzner listées ont un score ≤ 2, filtré par le script) : sans ajout manuel, elle ne serait jamais bannie.

## Changements

- Ajout de `94.130.70.34` à la blacklist spécifique de `blacklist-ips.sh` (réappliquée chaque nuit à 04h par cron sur tous les hôtes).

## Remarques

- Ban immédiat déjà applicable à la main en attendant le déploiement : `sudo /opt/app/tools/jail/ban-ip.sh 94.130.70.34` (jail `nginx-conn-limit-long`, 30 j).
- Le volet préventif (rate limiting nginx sur les routes front) est traité côté app : mission-apprentissage/labonnealternance PR 5076.